### PR TITLE
Remove superfluous space in sed command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN yum install -y libcurl-devel gcc sudo make &&\
 
 # Edit sudoers file
 # To avoid error: sudo: sorry, you must have a tty to run sudo
-RUN sed -i -e "s/Defaults    requiretty.*/ #Defaults    requiretty/g" /etc/sudoers
+RUN sed -i -e "s/Defaults    requiretty.*/#Defaults    requiretty/g" /etc/sudoers
 
 # Install td-agent
 RUN curl -L http://toolbelt.treasuredata.com/sh/install-redhat-td-agent2.sh | sh


### PR DESCRIPTION
Having a space before the # character is probably okay for the sudoers file, but this is cleaner.

Note that http://unix.stackexchange.com/questions/122616/why-do-i-need-a-tty-to-run-sudo-if-i-can-sudo-without-a-password/271247#271247 also retains the superfluous space.
